### PR TITLE
chore: performance improve, fix minor aria and disaplay bugs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ description: 'Suzu is a minimalist blog template with a serene sakura-inspired t
 keywords: 'Suzu, Next.js, markdown blog, Tailwind CSS, blog template, sakura, ZL Asica' # Comma-separated keywords for SEO purposes.
 author:
   name: 'ZL Asica' # Your name, displayed as the author of the blog.
-  link: 'https://www.zla.app' # Link to your personal website or blog.
+  link: 'https://www.zla.pub' # Link to your personal website or blog.
 # Language setting: Use ISO 639-1 code (e.g., 'en' for English, 'zh' for Chinese)
 lang: 'zh'
 # Your public root url, used for SEO and meta tags.
@@ -64,13 +64,6 @@ socialMedia:
   bilibili_id: 29018759 # Your Bilibili ID. https://space.bilibili.com/username
   email: zl@zla.app # Your email address.
   rss: true # Display the RSS icon.
-
-#######################
-# PAGES (ABOUT, FRIENDS) SETTINGS
-#######################
-# Have thumbnails for the about and friends pages.
-thumbnailAbout: false
-thumbnailFriends: false
 
 #######################
 # COMMENTS SETTINGS

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "funding": "https://github.com/sponsors/ZL-Asica",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "NODE_NO_WARNINGS=1 next build",
     "start": "next start",
     "format": "prettier --write .",
     "lint": "next lint",
@@ -31,7 +31,7 @@
     "es-toolkit": "^1.29.0",
     "gray-matter": "^4.0.3",
     "katex": "^0.16.15",
-    "next": "15.0.4",
+    "next": "15.1.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-icons": "^5.4.0",
@@ -47,7 +47,7 @@
     "yaml": "^2.6.1"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "^15.0.4",
+    "@next/eslint-plugin-next": "^15.1.0",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^22.10.1",
     "@types/react": "^19.0.1",
@@ -76,10 +76,6 @@
     "**/*.{css,json,md}": [
       "prettier --write"
     ]
-  },
-  "engines": {
-    "node": ">=20",
-    "pnpm": ">=9"
   },
   "browserslist": {
     "production": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@vercel/analytics':
         specifier: ^1.4.1
-        version: 1.4.1(next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 1.4.1(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 1.1.0(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@zl-asica/react':
         specifier: ^0.3.10
         version: 0.3.10(react@19.0.0)
@@ -30,8 +30,8 @@ importers:
         specifier: ^0.16.15
         version: 0.16.15
       next:
-        specifier: 15.0.4
-        version: 15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 15.1.0
+        version: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -73,8 +73,8 @@ importers:
         version: 2.6.1
     devDependencies:
       '@next/eslint-plugin-next':
-        specifier: ^15.0.4
-        version: 15.0.4
+        specifier: ^15.1.0
+        version: 15.1.0
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.15(tailwindcss@3.4.16)
@@ -587,56 +587,56 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@next/env@15.0.4':
-    resolution: {integrity: sha512-WNRvtgnRVDD4oM8gbUcRc27IAhaL4eXQ/2ovGbgLnPGUvdyDr8UdXP4Q/IBDdAdojnD2eScryIDirv0YUCjUVw==}
+  '@next/env@15.1.0':
+    resolution: {integrity: sha512-UcCO481cROsqJuszPPXJnb7GGuLq617ve4xuAyyNG4VSSocJNtMU5Fsx+Lp6mlN8c7W58aZLc5y6D/2xNmaK+w==}
 
-  '@next/eslint-plugin-next@15.0.4':
-    resolution: {integrity: sha512-rbsF17XGzHtR7SDWzWpavSfum3/UdnF8bAaisnKwP//si3KWPTedVUsflAdjyK1zW3rweBjbALfKcavFneLGvg==}
+  '@next/eslint-plugin-next@15.1.0':
+    resolution: {integrity: sha512-+jPT0h+nelBT6HC9ZCHGc7DgGVy04cv4shYdAe6tKlEbjQUtwU3LzQhzbDHQyY2m6g39m6B0kOFVuLGBrxxbGg==}
 
-  '@next/swc-darwin-arm64@15.0.4':
-    resolution: {integrity: sha512-QecQXPD0yRHxSXWL5Ff80nD+A56sUXZG9koUsjWJwA2Z0ZgVQfuy7gd0/otjxoOovPVHR2eVEvPMHbtZP+pf9w==}
+  '@next/swc-darwin-arm64@15.1.0':
+    resolution: {integrity: sha512-ZU8d7xxpX14uIaFC3nsr4L++5ZS/AkWDm1PzPO6gD9xWhFkOj2hzSbSIxoncsnlJXB1CbLOfGVN4Zk9tg83PUw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.0.4':
-    resolution: {integrity: sha512-pb7Bye3y1Og3PlCtnz2oO4z+/b3pH2/HSYkLbL0hbVuTGil7fPen8/3pyyLjdiTLcFJ+ymeU3bck5hd4IPFFCA==}
+  '@next/swc-darwin-x64@15.1.0':
+    resolution: {integrity: sha512-DQ3RiUoW2XC9FcSM4ffpfndq1EsLV0fj0/UY33i7eklW5akPUCo6OX2qkcLXZ3jyPdo4sf2flwAED3AAq3Om2Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.0.4':
-    resolution: {integrity: sha512-12oSaBFjGpB227VHzoXF3gJoK2SlVGmFJMaBJSu5rbpaoT5OjP5OuCLuR9/jnyBF1BAWMs/boa6mLMoJPRriMA==}
+  '@next/swc-linux-arm64-gnu@15.1.0':
+    resolution: {integrity: sha512-M+vhTovRS2F//LMx9KtxbkWk627l5Q7AqXWWWrfIzNIaUFiz2/NkOFkxCFyNyGACi5YbA8aekzCLtbDyfF/v5Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.0.4':
-    resolution: {integrity: sha512-QARO88fR/a+wg+OFC3dGytJVVviiYFEyjc/Zzkjn/HevUuJ7qGUUAUYy5PGVWY1YgTzeRYz78akQrVQ8r+sMjw==}
+  '@next/swc-linux-arm64-musl@15.1.0':
+    resolution: {integrity: sha512-Qn6vOuwaTCx3pNwygpSGtdIu0TfS1KiaYLYXLH5zq1scoTXdwYfdZtwvJTpB1WrLgiQE2Ne2kt8MZok3HlFqmg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.0.4':
-    resolution: {integrity: sha512-Z50b0gvYiUU1vLzfAMiChV8Y+6u/T2mdfpXPHraqpypP7yIT2UV9YBBhcwYkxujmCvGEcRTVWOj3EP7XW/wUnw==}
+  '@next/swc-linux-x64-gnu@15.1.0':
+    resolution: {integrity: sha512-yeNh9ofMqzOZ5yTOk+2rwncBzucc6a1lyqtg8xZv0rH5znyjxHOWsoUtSq4cUTeeBIiXXX51QOOe+VoCjdXJRw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.0.4':
-    resolution: {integrity: sha512-7H9C4FAsrTAbA/ENzvFWsVytqRYhaJYKa2B3fyQcv96TkOGVMcvyS6s+sj4jZlacxxTcn7ygaMXUPkEk7b78zw==}
+  '@next/swc-linux-x64-musl@15.1.0':
+    resolution: {integrity: sha512-t9IfNkHQs/uKgPoyEtU912MG6a1j7Had37cSUyLTKx9MnUpjj+ZDKw9OyqTI9OwIIv0wmkr1pkZy+3T5pxhJPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.0.4':
-    resolution: {integrity: sha512-Z/v3WV5xRaeWlgJzN9r4PydWD8sXV35ywc28W63i37G2jnUgScA4OOgS8hQdiXLxE3gqfSuHTicUhr7931OXPQ==}
+  '@next/swc-win32-arm64-msvc@15.1.0':
+    resolution: {integrity: sha512-WEAoHyG14t5sTavZa1c6BnOIEukll9iqFRTavqRVPfYmfegOAd5MaZfXgOGG6kGo1RduyGdTHD4+YZQSdsNZXg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.0.4':
-    resolution: {integrity: sha512-NGLchGruagh8lQpDr98bHLyWJXOBSmkEAfK980OiNBa7vNm6PsNoPvzTfstT78WyOeMRQphEQ455rggd7Eo+Dw==}
+  '@next/swc-win32-x64-msvc@15.1.0':
+    resolution: {integrity: sha512-J1YdKuJv9xcixzXR24Dv+4SaDKc2jj31IVUEMdO5xJivMTXuE6MAdIi4qPjSymHuFG8O5wbfWKnhJUcHHpj5CA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -663,8 +663,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.13':
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tailwindcss/typography@0.5.15':
     resolution: {integrity: sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==}
@@ -2266,16 +2266,16 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.0.4:
-    resolution: {integrity: sha512-nuy8FH6M1FG0lktGotamQDCXhh5hZ19Vo0ht1AOIQWrYJLP598TIUagKtvJrfJ5AGwB/WmDqkKaKhMpVifvGPA==}
+  next@15.1.0:
+    resolution: {integrity: sha512-QKhzt6Y8rgLNlj30izdMbxAwjHMFANnLwDwZ+WQh5sMhyt4lEBqDK9QpvWHtIM4rINKPoJ8aiRZKg5ULSybVHw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.41.2
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -3862,34 +3862,34 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@next/env@15.0.4': {}
+  '@next/env@15.1.0': {}
 
-  '@next/eslint-plugin-next@15.0.4':
+  '@next/eslint-plugin-next@15.1.0':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.0.4':
+  '@next/swc-darwin-arm64@15.1.0':
     optional: true
 
-  '@next/swc-darwin-x64@15.0.4':
+  '@next/swc-darwin-x64@15.1.0':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.0.4':
+  '@next/swc-linux-arm64-gnu@15.1.0':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.0.4':
+  '@next/swc-linux-arm64-musl@15.1.0':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.0.4':
+  '@next/swc-linux-x64-gnu@15.1.0':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.0.4':
+  '@next/swc-linux-x64-musl@15.1.0':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.0.4':
+  '@next/swc-win32-arm64-msvc@15.1.0':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.0.4':
+  '@next/swc-win32-x64-msvc@15.1.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3911,7 +3911,7 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/helpers@0.5.13':
+  '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
@@ -4056,14 +4056,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/analytics@1.4.1(next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@vercel/analytics@1.4.1(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     optionalDependencies:
-      next: 15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  '@vercel/speed-insights@1.1.0(next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@vercel/speed-insights@1.1.0(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     optionalDependencies:
-      next: 15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
   '@zl-asica/prettier-config@1.0.9(prettier@3.4.2)':
@@ -5916,11 +5916,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@next/env': 15.0.4
+      '@next/env': 15.1.0
       '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
+      '@swc/helpers': 0.5.15
       busboy: 1.6.0
       caniuse-lite: 1.0.30001687
       postcss: 8.4.31
@@ -5928,14 +5928,14 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.4
-      '@next/swc-darwin-x64': 15.0.4
-      '@next/swc-linux-arm64-gnu': 15.0.4
-      '@next/swc-linux-arm64-musl': 15.0.4
-      '@next/swc-linux-x64-gnu': 15.0.4
-      '@next/swc-linux-x64-musl': 15.0.4
-      '@next/swc-win32-arm64-msvc': 15.0.4
-      '@next/swc-win32-x64-msvc': 15.0.4
+      '@next/swc-darwin-arm64': 15.1.0
+      '@next/swc-darwin-x64': 15.1.0
+      '@next/swc-linux-arm64-gnu': 15.1.0
+      '@next/swc-linux-arm64-musl': 15.1.0
+      '@next/swc-linux-x64-gnu': 15.1.0
+      '@next/swc-linux-x64-musl': 15.1.0
+      '@next/swc-win32-arm64-msvc': 15.1.0
+      '@next/swc-win32-x64-msvc': 15.1.0
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/posts/_pages/About.md
+++ b/posts/_pages/About.md
@@ -3,6 +3,7 @@ title: '' # (Optional) Default is About
 thumbnail: '' # (Optional) You can put your personal about thumbnail
 showComments: false # Set whether you want have comment for this page
 showLicense: false # Set whether you want to show license for this page
+showThumbnail: false # Whether you want to show 'in page' thumbnail.
 ---
 
 ## 自我介绍

--- a/posts/_pages/Friends.md
+++ b/posts/_pages/Friends.md
@@ -3,6 +3,7 @@ title: Some Customized Title # (Optional) Default is Friends
 thumbnail: '' # (Optional) You can put your personal about thumbnail
 showComments: true # Set whether you want have comment for this page
 showLicense: false # Set whether you want to show license for this page
+showThumbnail: false # Whether you want to show 'in page' thumbnail.
 ---
 
 ## 我的项目

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -64,7 +64,6 @@ async function AboutPage() {
       <ArticlePage
         config={config}
         post={post}
-        showThumbnail={config.thumbnailAbout}
       />
     </>
   );

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -66,7 +66,6 @@ async function FriendsPage() {
       <ArticlePage
         config={config}
         post={post}
-        showThumbnail={config.thumbnailFriends}
       />
     </>
   );

--- a/src/components/article/ArticlePage.tsx
+++ b/src/components/article/ArticlePage.tsx
@@ -21,15 +21,14 @@ const DisqusComments = dynamic(() =>
 interface PostLayoutProperties {
   config: Config;
   post: FullPostData;
-  showThumbnail?: boolean;
 }
 
-const ArticlePage = ({ config, post, showThumbnail = true }: PostLayoutProperties) => {
+const ArticlePage = ({ config, post }: PostLayoutProperties) => {
   const translation = config.translation;
 
   return (
     <article className='container mx-auto animate-fadeInDown p-6 pb-2'>
-      {showThumbnail ? (
+      {post.frontmatter.showThumbnail ? (
         <Thumbnail
           title={post.frontmatter.title}
           src={post.frontmatter.thumbnail}
@@ -69,7 +68,7 @@ const ArticlePage = ({ config, post, showThumbnail = true }: PostLayoutPropertie
             items={post.toc}
             translation={translation}
             autoSlug={post.frontmatter.autoSlug}
-            showThumbnail={showThumbnail}
+            showThumbnail={post.frontmatter.showThumbnail}
           />
         )}
         <MarkdownContent

--- a/src/components/article/TOC.tsx
+++ b/src/components/article/TOC.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FaListUl } from 'react-icons/fa';
+import { FaListUl } from 'react-icons/fa6';
 import { useIsTop } from '@zl-asica/react';
 
 import TOCLink from './TOCLink';
@@ -37,7 +37,7 @@ const TOC = ({
       >
         <FaListUl size={20} />
       </button>
-      <nav
+      <menu
         ref={tocReference}
         hidden={!isVisible}
         className={`fixed bottom-40 top-auto z-40 max-h-[60vh] w-auto max-w-56 overflow-auto rounded-lg bg-[var(--lightGray)] p-3 shadow-md transition-all xl:bottom-auto xl:top-36 ${
@@ -47,18 +47,21 @@ const TOC = ({
         <h2 className='mb-4 text-lg font-semibold text-[var(--sakuraPink)]'>
           {translation.post.toc}
         </h2>
-        {items.map((item) => (
-          <TOCLink
-            key={item.slug}
-            item={item}
-            activeSlug={activeSlug}
-            handleLinkClick={handleLinkClick}
-            autoSlug={autoSlug}
-          />
-        ))}
-      </nav>
+        <ul className='m-0 list-none p-0'>
+          {items.map((item) => (
+            <TOCLink
+              key={item.slug}
+              item={item}
+              activeSlug={activeSlug}
+              handleLinkClick={handleLinkClick}
+              autoSlug={autoSlug}
+            />
+          ))}
+        </ul>
+      </menu>
     </div>
   );
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export default TOC;

--- a/src/components/article/TOCLink.tsx
+++ b/src/components/article/TOCLink.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+'use client';
 
 import { slugPrefix } from '@/services/utils';
 
@@ -14,24 +14,24 @@ const TOCLink = ({ item, activeSlug, handleLinkClick, autoSlug }: TOCLinkPropert
   const titleSlug = autoSlug ? `${slugPrefix(item.slug, item.level)} ` : '';
 
   return (
-    <div
+    <li
       key={item.slug}
+      className={`list-none py-1 text-base transition-colors duration-200 ${
+        isActive ? 'font-bold text-[var(--sakuraPink)]' : 'text-[var(--gray)]'
+      } `}
       style={{ marginLeft: `${(item.level - 2) * 0.8}em` }}
     >
-      <Link
+      <a
         href={`#${item.slug}`}
-        scroll={false}
         onClick={(event) => {
           event.preventDefault();
           handleLinkClick(item.slug);
         }}
-        className={`block py-1 text-base no-underline transition-colors duration-200 ${
-          isActive ? 'font-bold text-[var(--sakuraPink)]' : 'text-[var(--gray)]'
-        } break-words`}
+        className={`block break-words no-underline`}
       >
         {`${titleSlug}${item.title}`}
-      </Link>
-    </div>
+      </a>
+    </li>
   );
 };
 

--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FaArrowUp } from 'react-icons/fa';
+import { FaArrowUp } from 'react-icons/fa6';
 import { useIsBottom, backToTop, useIsTop } from '@zl-asica/react';
 import { usePathname } from 'next/navigation';
 

--- a/src/services/content/getPostFromFile.ts
+++ b/src/services/content/getPostFromFile.ts
@@ -31,6 +31,7 @@ function getPostFromFile(
     redirect: defaultTo(data.redirect),
     showComments: defaultTo(data.showComments, true),
     showLicense: defaultTo(data.showLicense, true),
+    showThumbnail: defaultTo(data.showThumbnail, true),
     autoSlug: defaultTo(data.autoSlug, true)
   };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,7 @@ interface Frontmatter {
   redirect?: string;
   showComments?: boolean;
   showLicense?: boolean;
+  showThumbnail?: boolean;
   autoSlug?: boolean;
 }
 
@@ -56,8 +57,6 @@ interface UserConfig {
   travellings: boolean | null;
   startYear: number | null;
   socialMedia: SocialMedia;
-  thumbnailAbout: boolean;
-  thumbnailFriends: boolean;
   twikooEnvId: string | null;
   disqusShortname: string | null;
   slotFooter: string;


### PR DESCRIPTION
Chore:
- Remove `thumbnailAbout` and `thumbnailFriends` options from config, enable `showThumbnail` option for frontmatter for each page to use.
- Change all icons to use `fa6` instead of others to reduce bundling size.
- Remove not-exist prop `onLinkClick` from `useTOCLogic` hook.

Fix:
- Aria issue with TOC, use `menu` instead of `nav`. Use `ul` + `li` instead of `div`.
- TOC link switch to barebone `<a>` tag instead of nextjs `Link` components to avoid prefetch cost performance.
- Auto slug activate may exceed viewport and not centered even possible.

Deps:
- Upgrade nextjs to `15.1.0`
- Remove `engine` part since controlled by `packageManager` and `node-version`