### PR TITLE
docs(project): align repository documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+Use this file as the working contract for future coding agents (e.g., Codex, Claude Code) runs in this repository. Inspect first, then change. Prefer small, coherent edits that match the existing Next.js App Router structure.
+
+## Related Docs
+
+- [`README.md`](./README.md): project overview and quick start.
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md): source layout, content model, generated outputs, and config ownership.
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md): local setup, content editing, validation, and deployment notes.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md): contributor workflow, code style, and PR checklist.
+
+Agents should follow `CONTRIBUTING.md` unless the user explicitly asks for a different structure.
+
+## Repo Overview
+
+- This is a Next.js App Router blog template, not a TanStack Start app.
+- The app uses React 19, TypeScript, Tailwind CSS v4, Markdown content files, Zod validation, and Vercel for deployment.
+- Package manager: `pnpm`.
+- This repository has no database, auth system, or custom API runtime.
+
+## Source Layout
+
+- `src/app`: Next.js routes, metadata, sitemap, robots, manifest, and loading states.
+- `src/components`: reusable UI, grouped by surface such as article, posts, anime, common, and ui.
+- `src/hooks`: client hooks for search, URL state, and table-of-contents logic.
+- `src/lib`: shared metadata, JSON-LD, social data, and pure helpers.
+- `src/schemas`: Zod schemas for config and content-adjacent data.
+- `src/services`: config loading, content loading, and generated RSS/LLM output.
+- `src/styles`: theme and utility CSS.
+- `src/types`: global types.
+- `posts`: Markdown posts; `posts/_pages` contains special pages.
+- `public`: static assets and generated public files.
+
+## Architecture Expectations
+
+- Keep route files focused on framework integration and page composition.
+- Keep content parsing in `src/services/content` and config loading in `src/services/config`.
+- Keep generated RSS, LLM, image URL, and slug helpers in `src/services/utils` unless there is a clear reason to move them.
+- Preserve alias usage with `@/...`; do not add another source alias.
+- When adding config fields, update `config.yml`, `src/schemas/config.ts`, and any relevant docs together.
+- Reuse existing metadata and JSON-LD helpers instead of hand-building metadata in individual routes.
+
+## Content Guidance
+
+- Top-level `posts/*.md` files are blog posts.
+- `posts/_pages/About.md` and `posts/_pages/Friends.md` back the `/about` and `/friends` pages.
+- Use the existing frontmatter shape and visibility rules from `src/services/content/postVisibility.ts`.
+- Generated files in `public/feed.xml`, `public/llms.txt`, and `public/llms-full.txt` are derived from published posts and site config. Review generated diffs before committing.
+
+## Validation and Testing
+
+- Inspect available scripts before choosing commands.
+- Run the most relevant validation for the files changed.
+- Use `pnpm lint:fix` for automatic formatting and linting fixes.
+- Use `pnpm run build` for code, route, config schema, content pipeline, or generated-output changes.
+- There is currently no `pnpm test` script nor test framework right now.
+- If validation fails, report the command, the failure, and whether it appears related to the current change.
+
+## Commits and Branches
+
+- Keep commits small, coherent, and conventional when commits are requested.
+- Prefer commit messages such as:
+  - `docs(project): align contributor guide`
+  - `feat(markdown): add excerpt support with <!--more-->`
+  - `fix(content): preserve unlisted post metadata`
+
+Before presenting work as ready, state clearly:
+
+- what branch the work is on
+- what commits were created, if any
+- what validation passed
+- what validation was not run and why
+- whether any known or unrelated failures remain

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Architecture
 
-SuzuBlog is a minimalist blog template built with Next.js App Router, React, TypeScript, Tailwind CSS, and Markdown content files. It is designed to be deployed as a static-friendly Next.js site, with optional deployment to Vercel support.
+[English](./ARCHITECTURE.md) | [中文](./ARCHITECTURE_ZH.md)
+
+SuzuBlog is a minimalist blog template built with Next.js App Router, React, TypeScript, Tailwind CSS, and Markdown content files. It is designed to be deployed as a static-friendly Next.js site, with first-class Vercel support.
 
 ## Runtime Model
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,94 @@
+# Architecture
+
+SuzuBlog is a minimalist blog template built with Next.js App Router, React, TypeScript, Tailwind CSS, and Markdown content files. It is designed to be deployed as a static-friendly Next.js site, with optional deployment to Vercel support.
+
+## Runtime Model
+
+- Next.js App Router owns routing, metadata, sitemap, robots, manifest, and page rendering under `src/app`.
+- Blog content is stored as Markdown files in `posts`.
+- Site-wide settings are stored in `config.yml` and validated with Zod before use.
+- Public assets live in `public`; images referenced by config and posts should usually be placed under `public/images`.
+- RSS and LLM text files are generated into `public` during static parameter generation for posts.
+
+The project does not use a database, custom API server, authentication provider, or serverless mail/runtime bindings.
+
+## Source Layout
+
+```text
+src/
+  app/          Next.js App Router routes, metadata, sitemap, robots, manifest
+  components/   Reusable UI grouped by domain and surface
+  hooks/        Client hooks for search, URL state, and table of contents logic
+  lib/          Shared metadata, JSON-LD, social data, and pure helpers
+  schemas/      Zod schemas for config and content-adjacent data
+  services/     Content loading, config loading, and generated output utilities
+  styles/       Tailwind theme and utility CSS
+  types/        Global project types
+```
+
+Keep route files focused on page composition and framework integration. Content parsing, config loading, generated files, and reusable logic should stay in `src/services` or `src/lib`, following the current split.
+
+## Content Model
+
+Top-level Markdown files in `posts/*.md` become blog posts. Special pages live in `posts/_pages`:
+
+- `posts/_pages/About.md` renders at `/about`.
+- `posts/_pages/Friends.md` renders at `/friends`.
+
+Post frontmatter is parsed with `gray-matter`. Common fields include:
+
+- `title`
+- `date`
+- `thumbnail`
+- `categories`
+- `tags`
+- `redirect`
+- `showComments`
+- `showLicense`
+- `showThumbnail`
+- `autoSlug`
+- `status`
+
+`status` supports `published`, `unlisted`, `draft`, and `hidden`.
+
+- `published` posts appear in lists, pages, RSS, LLM output, and sitemap.
+- `unlisted` posts can render as pages but do not appear in lists or generated crawler files.
+- `draft` posts are available outside production, or in production when `ALLOW_DRAFTS=true`.
+- `hidden` posts are only available outside production when `ALLOW_HIDDEN=true`.
+
+Redirect posts use `redirect` in frontmatter. The dynamic post page redirects before rendering article content.
+
+## Configuration
+
+`config.yml` is the source of truth for site identity, SEO defaults, social links, comments, icons, analytics, and content display settings. It is loaded by `src/services/config/configLoader.ts` and validated against `src/schemas/config.ts`.
+
+When adding a new config key:
+
+1. Update `config.yml` with comments and a safe default.
+2. Update the Zod schema in `src/schemas/config.ts`.
+3. Update consumers through the existing config service.
+4. Update README or development docs if users need to know about the option.
+
+## Generated Outputs
+
+The dynamic post route generates supporting public files while collecting static params:
+
+- `public/feed.xml`
+- `public/llms.txt`
+- `public/llms-full.txt`
+
+These files are derived from published posts and site config. Keep generated output logic in `src/services/utils` and avoid duplicating post filtering rules.
+
+## SEO and Metadata
+
+Metadata is centralized in `src/lib/buildMetadata.ts`, with JSON-LD helpers in `src/lib/buildJsonLd.ts`. Routes should use those helpers instead of building metadata objects ad hoc.
+
+`src/app/sitemap.ts`, `src/app/robots.ts`, and post metadata all rely on the same post visibility rules from `src/services/content/postVisibility.ts`. Changes to visibility behavior should update every dependent output consistently.
+
+## Styling
+
+Tailwind CSS v4 is configured through PostCSS and the global CSS files in `src/app/globals.css`, `src/styles/theme.css`, and `src/styles/utilities.css`. Reusable UI belongs in `src/components`; small one-off page composition can stay in the relevant route.
+
+## Documentation Maintenance
+
+Update this document when changing stable project boundaries such as source layout, content visibility, config ownership, generated outputs, deployment assumptions, or metadata behavior.

--- a/ARCHITECTURE_ZH.md
+++ b/ARCHITECTURE_ZH.md
@@ -1,0 +1,96 @@
+# 架构说明
+
+[English](./ARCHITECTURE.md) | [中文](./ARCHITECTURE_ZH.md)
+
+SuzuBlog 是一个极简博客模板，基于 Next.js App Router、React、TypeScript、Tailwind CSS 和 Markdown 内容文件构建。它适合以静态友好的 Next.js 站点形式部署，并对 Vercel 部署提供一等支持。
+
+## 运行模型
+
+- Next.js App Router 负责 `src/app` 下的路由、元数据、站点地图、robots、manifest 和页面渲染。
+- 博客内容存放在 `posts` 目录中的 Markdown 文件里。
+- 站点级设置存放在 `config.yml`，使用前会通过 Zod 校验。
+- 公共资源存放在 `public`；配置和文章引用的图片通常放在 `public/images`。
+- RSS 和 LLM 文本文件会在文章静态参数生成阶段输出到 `public`。
+
+这个项目不使用数据库、自定义 API 服务、认证系统，也不依赖服务端邮件或运行时绑定。
+
+## 源码结构
+
+```text
+src/
+  app/          Next.js App Router routes, metadata, sitemap, robots, manifest
+  components/   Reusable UI grouped by domain and surface
+  hooks/        Client hooks for search, URL state, and table of contents logic
+  lib/          Shared metadata, JSON-LD, social data, and pure helpers
+  schemas/      Zod schemas for config and content-adjacent data
+  services/     Content loading, config loading, and generated output utilities
+  styles/       Tailwind theme and utility CSS
+  types/        Global project types
+```
+
+路由文件应专注于页面组合和框架集成。内容解析、配置加载、生成文件和可复用逻辑应保留在 `src/services` 或 `src/lib`，遵循当前分层。
+
+## 内容模型
+
+`posts/*.md` 中的顶层 Markdown 文件会成为博客文章。特殊页面放在 `posts/_pages`：
+
+- `posts/_pages/About.md` 渲染到 `/about`。
+- `posts/_pages/Friends.md` 渲染到 `/friends`。
+
+文章 frontmatter 使用 `gray-matter` 解析。常见字段包括：
+
+- `title`
+- `date`
+- `thumbnail`
+- `categories`
+- `tags`
+- `redirect`
+- `showComments`
+- `showLicense`
+- `showThumbnail`
+- `autoSlug`
+- `status`
+
+`status` 支持 `published`、`unlisted`、`draft` 和 `hidden`。
+
+- `published` 文章会出现在列表、页面、RSS、LLM 输出和站点地图中。
+- `unlisted` 文章可以渲染页面，但不会出现在列表或生成给爬虫使用的文件中。
+- `draft` 文章在非生产环境可用；生产环境需要设置 `ALLOW_DRAFTS=true`。
+- `hidden` 文章只会在非生产环境且 `ALLOW_HIDDEN=true` 时可用。
+
+重定向文章通过 frontmatter 中的 `redirect` 配置。动态文章页会在渲染正文前执行重定向。
+
+## 配置
+
+`config.yml` 是站点身份、SEO 默认值、社交链接、评论、图标、分析和内容展示设置的来源。它由 `src/services/config/configLoader.ts` 加载，并通过 `src/schemas/config.ts` 校验。
+
+新增配置项时：
+
+1. 在 `config.yml` 中加入说明和安全默认值。
+2. 更新 `src/schemas/config.ts` 中的 Zod schema。
+3. 通过现有 config service 更新使用方。
+4. 如果用户需要了解这个选项，同步更新 README 或开发文档。
+
+## 生成输出
+
+动态文章路由在收集静态参数时会生成辅助公开文件：
+
+- `public/feed.xml`
+- `public/llms.txt`
+- `public/llms-full.txt`
+
+这些文件由已发布文章和站点配置生成。生成输出逻辑应保留在 `src/services/utils`，避免重复实现文章过滤规则。
+
+## SEO 和元数据
+
+元数据集中在 `src/lib/buildMetadata.ts`，JSON-LD 辅助函数位于 `src/lib/buildJsonLd.ts`。路由应复用这些 helper，而不是在各自文件里临时拼装 metadata。
+
+`src/app/sitemap.ts`、`src/app/robots.ts` 和文章元数据都依赖 `src/services/content/postVisibility.ts` 中的同一套文章可见性规则。修改可见性行为时，应同步更新所有依赖输出。
+
+## 样式
+
+Tailwind CSS v4 通过 PostCSS 以及 `src/app/globals.css`、`src/styles/theme.css`、`src/styles/utilities.css` 中的全局 CSS 配置。可复用 UI 放在 `src/components`；小范围的一次性页面组合可以留在对应路由中。
+
+## 文档维护
+
+当源码布局、内容可见性、配置归属、生成输出、部署假设或元数据行为等稳定边界发生变化时，请更新本文档。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,178 +2,161 @@
 
 # Contributing to SuzuBlog
 
-First off, thanks for taking the time to contribute! ❤️
+Thanks for taking the time to contribute. SuzuBlog is a Next.js + Markdown blog template, so changes should stay small, practical, and easy for site owners to adapt.
 
-All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
-
-> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
->
-> - Star the project
-> - Tweet about it
-> - Refer this project in your project's readme
-> - Mention the project at local meetups and tell your friends/colleagues
-
-<!-- omit in toc -->
+Please also read the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Table of Contents
 
 - [Contributing to SuzuBlog](#contributing-to-suzublog)
   - [Table of Contents](#table-of-contents)
-  - [Code of Conduct](#code-of-conduct)
   - [I Have a Question](#i-have-a-question)
-  - [I Want To Contribute](#i-want-to-contribute)
-    - [Reporting Bugs](#reporting-bugs)
-      - [Before Submitting a Bug Report](#before-submitting-a-bug-report)
-      - [How Do I Submit a Good Bug Report?](#how-do-i-submit-a-good-bug-report)
-    - [Suggesting Enhancements](#suggesting-enhancements)
-      - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
-      - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
-    - [Your First Code Contribution](#your-first-code-contribution)
-    - [Improving The Documentation](#improving-the-documentation)
-  - [Styleguides](#styleguides)
-    - [Commit Messages](#commit-messages)
-  - [Join The Project Team](#join-the-project-team)
-  - [Attribution](#attribution)
-
-## Code of Conduct
-
-This project and everyone participating in it is governed by the
-[SuzuBlog Code of Conduct](https://github.com/ZL-Asica/SuzuBlog/blob/main/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report unacceptable behavior
-to <zl@zla.app>.
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Local Development](#local-development)
+  - [Code Organization](#code-organization)
+  - [Content and Config Changes](#content-and-config-changes)
+  - [Style Guide](#style-guide)
+  - [Validation](#validation)
+  - [Pull Request Checklist](#pull-request-checklist)
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://suzu.zla.app).
+Before opening a question, check the [documentation](https://suzu.zla.app), existing [issues](https://github.com/ZL-Asica/SuzuBlog/issues), and the README.
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/ZL-Asica/SuzuBlog/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+When opening an issue, include the relevant versions, operating system, browser if applicable, and enough context for maintainers to reproduce or understand the problem.
 
-If you then still feel the need to ask a question and need clarification, we recommend the following:
+## Reporting Bugs
 
-- Open an [Issue](https://github.com/ZL-Asica/SuzuBlog/issues/new).
-- Provide as much context as you can about what you're running into.
-- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+Before submitting a bug report:
 
-We will then take care of the issue as soon as possible.
+- Make sure you are using the latest available version.
+- Check whether the issue is caused by local config, unsupported runtime versions, or invalid Markdown/frontmatter.
+- Search existing issues to avoid duplicates.
+- Reduce the reproduction to the smallest possible content, config, or code example.
 
-<!--
-You might want to create a separate issue tag for questions and include it in this description. People should then tag their issues accordingly.
+Good bug reports include:
 
-Depending on how large the project is, you may want to outsource the questioning, e.g. to Stack Overflow or Gitter. You may add additional contact and information possibilities:
-- IRC
-- Slack
-- Gitter
-- Stack Overflow tag
-- Blog
-- FAQ
-- Roadmap
-- E-Mail List
-- Forum
--->
+- expected behavior
+- actual behavior
+- reproduction steps
+- relevant `config.yml` values or post frontmatter
+- terminal output or screenshots when useful
+- Node.js and pnpm versions
 
-## I Want To Contribute
+Do not report security-sensitive information publicly. Send sensitive reports to <zl@zla.app>.
 
-> ### Legal Notice <!-- omit in toc -->
->
-> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+## Suggesting Enhancements
 
-### Reporting Bugs
+Enhancements are tracked through GitHub issues. A good suggestion explains:
 
-<!-- omit in toc -->
+- the current behavior
+- the proposed behavior
+- why the change fits a minimalist blog template
+- any compatibility or migration impact for existing users
 
-#### Before Submitting a Bug Report
+Features that only serve one private site may be better handled through local customization rather than added to the template.
 
-A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+## Local Development
 
-- Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://suzu.zla.app). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/ZL-Asica/SuzuBlog/issues?q=label%3Abug).
-- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
-- Collect information about the bug:
-  - Stack trace (Traceback)
-  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
-  - Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
-  - Possibly your input and the output
-  - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+Use the versions declared by the repository:
 
-<!-- omit in toc -->
+- Node.js >= 22 from `.node-version`
+- pnpm from `package.json`
 
-#### How Do I Submit a Good Bug Report?
+Install dependencies:
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <zl@zla.app>.
+```bash
+pnpm install
+```
 
-<!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
+Start development:
 
-We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+```bash
+pnpm dev
+```
 
-- Open an [Issue](https://github.com/ZL-Asica/SuzuBlog/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
-- Explain the behavior you would expect and the actual behavior.
-- Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
-- Provide the information you collected in the previous section.
+Open `http://localhost:3000/`.
 
-Once it's filed:
+See [DEVELOPMENT.md](./DEVELOPMENT.md) for content editing, generated files, and deployment notes.
 
-- The project team will label the issue accordingly.
-- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+## Code Organization
 
-<!-- You might want to create an issue template for bugs and errors that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+Follow the existing project structure:
 
-### Suggesting Enhancements
+```text
+src/app          Next.js App Router routes and metadata files
+src/components   Reusable UI grouped by surface
+src/hooks        Client hooks
+src/lib          Shared metadata, JSON-LD, and pure helpers
+src/schemas      Zod schemas
+src/services     Config, content, and generated-output utilities
+src/styles       Theme and utility CSS
+src/types        Global project types
+```
 
-This section guides you through submitting an enhancement suggestion for SuzuBlog, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+Keep route files focused on framework integration and page composition. Put content loading in `src/services/content`, config loading in `src/services/config`, and reusable generated-output helpers in `src/services/utils`.
 
-<!-- omit in toc -->
+Move code only when there is a clear existing reuse path. Avoid new folders, state managers, dependencies, or architectural layers unless the change needs them.
 
-#### Before Submitting an Enhancement
+## Content and Config Changes
 
-- Make sure that you are using the latest version.
-- Read the [documentation](https://suzu.zla.app) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://github.com/ZL-Asica/SuzuBlog/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
-- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+Posts live in `posts/*.md`. Special pages live in `posts/_pages`.
 
-<!-- omit in toc -->
+When editing posts:
 
-#### How Do I Submit a Good Enhancement Suggestion?
+- Use existing frontmatter conventions.
+- Use `<!--more-->` when you need a custom excerpt.
+- Put public images under `public/images` and reference them with root-relative paths such as `/images/example.jpg`.
+- Review visibility behavior before changing `status`.
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/ZL-Asica/SuzuBlog/issues).
+When editing `config.yml`:
 
-- Use a **clear and descriptive title** for the issue to identify the suggestion.
-- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
-- **Explain why this enhancement would be useful** to most SuzuBlog users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- Keep defaults safe for a public blog template.
+- Update `src/schemas/config.ts` for new or changed fields.
+- Update README or docs when users need to know about the option.
 
-<!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
+Generated files such as `public/feed.xml`, `public/llms.txt`, and `public/llms-full.txt` should be reviewed before commit.
 
-### Your First Code Contribution
+## Style Guide
 
-<!-- TODO
-include Setup of env, IDE and typical getting started instructions?
+- Prefer TypeScript with clear names and explicit data shapes.
+- Preserve `@/...` imports.
+- Use existing metadata, JSON-LD, config, and content helpers.
+- Keep UI accessible with semantic HTML, useful labels, keyboard-friendly interactions, and visible focus states.
+- Keep comments for non-obvious behavior; avoid comments that restate the code.
+- Do not add dependencies without a clear reason.
 
--->
+Commit messages should be concise and conventional when possible:
 
-### Improving The Documentation
+```text
+docs(project): update development guide
+fix(content): handle unlisted post metadata
+feat(ui): add compact post search
+```
 
-<!-- TODO
-Updating, improving and correcting the documentation
+## Validation
 
--->
+Run the most relevant checks for your change:
 
-## Styleguides
+```bash
+pnpm lint:fix
+```
 
-### Commit Messages
+For code, config schema, routing, content loading, or generated-output changes:
 
-<!-- TODO
+```bash
+pnpm run build
+```
 
--->
+There is no test script configured right now. If a change introduces behavior that needs automated coverage, discuss or add focused test infrastructure as part of that work.
 
-## Join The Project Team
+## Pull Request Checklist
 
-<!-- TODO -->
-
-<!-- omit in toc -->
-
-## Attribution
-
-This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!
+- The change has one clear purpose.
+- Project structure and existing naming conventions are preserved.
+- Content visibility, metadata, RSS, sitemap, and LLM output behavior are updated consistently when affected.
+- `config.yml` and `src/schemas/config.ts` stay in sync.
+- Documentation is updated when setup, config, architecture, or workflow changes.
+- Relevant validation commands were run, or skipped checks are explained.
+- UI changes were checked in the browser, including mobile layout when practical.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Features that only serve one private site may be better handled through local cu
 
 Use the versions declared by the repository:
 
-- Node.js >= 22 from `.node-version`
+- Node.js >= 20.9.0 from `.node-version`
 - pnpm from `package.json`
 
 Install dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 # Contributing to SuzuBlog
 
+[English](./CONTRIBUTING.md) | [中文](./CONTRIBUTING_ZH.md)
+
 Thanks for taking the time to contribute. SuzuBlog is a Next.js + Markdown blog template, so changes should stay small, practical, and easy for site owners to adapt.
 
 Please also read the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -1,0 +1,164 @@
+<!-- omit in toc -->
+
+# 为 SuzuBlog 做贡献
+
+[English](./CONTRIBUTING.md) | [中文](./CONTRIBUTING_ZH.md)
+
+感谢你愿意贡献。SuzuBlog 是一个 Next.js + Markdown 博客模板，所以改动应尽量小、实用，并且便于站点维护者按需调整。
+
+也请阅读 [行为准则](./CODE_OF_CONDUCT.md)。
+
+## 目录
+
+- [为 SuzuBlog 做贡献](#为-suzublog-做贡献)
+  - [目录](#目录)
+  - [我有问题](#我有问题)
+  - [报告 Bug](#报告-bug)
+  - [提出改进建议](#提出改进建议)
+  - [本地开发](#本地开发)
+  - [代码组织](#代码组织)
+  - [内容和配置变更](#内容和配置变更)
+  - [风格指南](#风格指南)
+  - [校验](#校验)
+  - [Pull Request 检查清单](#pull-request-检查清单)
+
+## 我有问题
+
+提问前，请先查看 [文档](https://suzu.zla.app)、已有 [issues](https://github.com/ZL-Asica/SuzuBlog/issues) 和 README。
+
+打开 issue 时，请提供相关版本、操作系统、浏览器（如果相关），以及足够让维护者理解或复现问题的上下文。
+
+## 报告 Bug
+
+提交 bug 报告前：
+
+- 确认你正在使用最新可用版本。
+- 检查问题是否由本地配置、不支持的运行时版本或无效 Markdown/frontmatter 引起。
+- 搜索已有 issue，避免重复提交。
+- 将复现缩小到最小可行的内容、配置或代码示例。
+
+好的 bug 报告应包含：
+
+- 期望行为
+- 实际行为
+- 复现步骤
+- 相关的 `config.yml` 值或文章 frontmatter
+- 有用的终端输出或截图
+- Node.js 和 pnpm 版本
+
+不要在公开 issue 中报告安全敏感信息。敏感报告请发送到 <zl@zla.app>。
+
+## 提出改进建议
+
+改进建议通过 GitHub issues 跟踪。好的建议会说明：
+
+- 当前行为
+- 期望行为
+- 为什么该变化适合一个极简博客模板
+- 对现有用户是否有兼容性或迁移影响
+
+只服务于某个私人站点的功能，可能更适合通过本地自定义实现，而不是加入模板。
+
+## 本地开发
+
+使用仓库声明的版本：
+
+- Node.js >= 22，参考 `.node-version`
+- pnpm，参考 `package.json`
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+启动开发环境：
+
+```bash
+pnpm dev
+```
+
+打开 `http://localhost:3000/`。
+
+内容编辑、生成文件和部署说明见 [DEVELOPMENT_ZH.md](./DEVELOPMENT_ZH.md)。
+
+## 代码组织
+
+遵循现有项目结构：
+
+```text
+src/app          Next.js App Router routes and metadata files
+src/components   Reusable UI grouped by surface
+src/hooks        Client hooks
+src/lib          Shared metadata, JSON-LD, and pure helpers
+src/schemas      Zod schemas
+src/services     Config, content, and generated-output utilities
+src/styles       Theme and utility CSS
+src/types        Global project types
+```
+
+路由文件应专注于框架集成和页面组合。内容加载放在 `src/services/content`，配置加载放在 `src/services/config`，可复用的生成输出 helper 放在 `src/services/utils`。
+
+只有存在明确复用路径时才移动代码。避免引入不必要的新文件夹、状态管理器、依赖或架构层。
+
+## 内容和配置变更
+
+文章放在 `posts/*.md`。特殊页面放在 `posts/_pages`。
+
+编辑文章时：
+
+- 使用现有 frontmatter 约定。
+- 需要自定义摘要时使用 `<!--more-->`。
+- 将公开图片放在 `public/images`，并使用 `/images/example.jpg` 这类根相对路径引用。
+- 修改 `status` 前先确认可见性行为。
+
+编辑 `config.yml` 时：
+
+- 为公开博客模板保留安全默认值。
+- 新增或修改字段时更新 `src/schemas/config.ts`。
+- 当用户需要了解某个选项时，同步更新 README 或文档。
+
+提交前请检查 `public/feed.xml`、`public/llms.txt`、`public/llms-full.txt` 这类生成文件。
+
+## 风格指南
+
+- 优先使用 TypeScript，并保持命名清晰、数据形状明确。
+- 保留 `@/...` imports。
+- 复用现有 metadata、JSON-LD、config 和 content helper。
+- UI 保持可访问性：语义化 HTML、有用的 label、键盘友好交互和可见 focus 状态。
+- 只为不明显的行为添加注释；避免重复解释代码本身。
+- 不要在没有明确理由的情况下添加依赖。
+
+Commit message 尽量简洁并遵循 conventional commit：
+
+```text
+docs(project): update development guide
+fix(content): handle unlisted post metadata
+feat(ui): add compact post search
+```
+
+## 校验
+
+运行与改动最相关的检查：
+
+```bash
+pnpm lint:fix
+```
+
+代码、配置 schema、路由、内容加载或生成输出变更：
+
+```bash
+pnpm run build
+```
+
+当前没有配置测试脚本。如果某个改动引入需要自动化覆盖的行为，请讨论或一并添加聚焦的测试基础设施。
+
+## Pull Request 检查清单
+
+- 改动只有一个清晰目的。
+- 保留项目结构和现有命名约定。
+- 影响内容可见性、metadata、RSS、sitemap 或 LLM 输出时，相关行为已同步更新。
+- `config.yml` 和 `src/schemas/config.ts` 保持一致。
+- 设置、配置、架构或工作流变化时已更新文档。
+- 已运行相关校验命令，或解释了跳过原因。
+- UI 变更已在浏览器中检查，实际可行时也检查移动端布局。

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -63,7 +63,7 @@
 
 使用仓库声明的版本：
 
-- Node.js >= 22，参考 `.node-version`
+- Node.js >= 20.9.0，参考 `.node-version`
 - pnpm，参考 `package.json`
 
 安装依赖：

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This guide covers local setup, content editing, validation, and deployment for S
 
 ## Prerequisites
 
-- Node.js >= 22, prefer matching `.node-version`
+- Node.js >= 20.9.0, prefer matching `.node-version`
 - pnpm, matching `packageManager` in `package.json`
 
 Install dependencies:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,153 @@
+# Development Guide
+
+This guide covers local setup, content editing, validation, and deployment for SuzuBlog.
+
+## Prerequisites
+
+- Node.js >= 22, prefer matching `.node-version`
+- pnpm, matching `packageManager` in `package.json`
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+## Local Development
+
+Start the app:
+
+```bash
+pnpm dev
+```
+
+Open:
+
+```text
+http://localhost:3000/
+```
+
+Build the production app:
+
+```bash
+pnpm run build
+```
+
+Start a built production app:
+
+```bash
+pnpm start
+```
+
+## Available Scripts
+
+- `pnpm dev`: start the Next.js development server.
+- `pnpm run build`: run `pnpm run lint:fix`, then `next build`.
+- `pnpm start`: start the production Next.js server after a build.
+- `pnpm lint`: run ESLint.
+- `pnpm lint:fix`: run ESLint with automatic fixes.
+
+There is no test script configured at the moment. Prefer `pnpm lint` or `pnpm run build` for documentation-adjacent changes, and add focused tests if a future change introduces test infrastructure.
+
+## Configuration
+
+Edit `config.yml` for site-wide settings:
+
+- title, subtitle, description, keywords, language, and site URL
+- author profile and avatar/background images
+- pagination and content license defaults
+- social links and RSS visibility
+- Twikoo or Disqus comment integration
+- custom head scripts and footer HTML
+
+Config is validated with Zod at runtime. If a new config field is added, update both `config.yml` and `src/schemas/config.ts`.
+
+## Content Editing
+
+Create posts as Markdown files in `posts`:
+
+```text
+posts/my-post.md
+```
+
+Special pages live in `posts/_pages`:
+
+```text
+posts/_pages/About.md
+posts/_pages/Friends.md
+```
+
+Typical post frontmatter:
+
+```yaml
+---
+title: My Post
+date: '2026-05-29 09:00:00'
+thumbnail: /images/background.jpg
+categories:
+  - Notes
+tags:
+  - Next.js
+  - Markdown
+---
+```
+
+Use `<!--more-->` to control the excerpt shown in post lists. Without it, the abstract is derived from the beginning of the post content.
+
+## Post Visibility
+
+Post visibility is controlled by the optional `status` frontmatter field:
+
+- `published`: visible in lists, generated pages, sitemap, RSS, and LLM files.
+- `unlisted`: page can render, but it is excluded from lists and generated crawler outputs.
+- `draft`: available outside production; production requires `ALLOW_DRAFTS=true`.
+- `hidden`: available only outside production with `ALLOW_HIDDEN=true`.
+
+If `status` is omitted, the post is treated as `published`.
+
+## Assets
+
+Put static assets under `public`. Images used by posts and config usually belong in `public/images` and are referenced from the site root:
+
+```md
+![Alt text](/images/example.jpg)
+```
+
+`next/image` allows local images under `/images/**` and remote HTTPS images.
+
+## Generated Files
+
+The build can regenerate:
+
+- `public/feed.xml`
+- `public/llms.txt`
+- `public/llms-full.txt`
+
+These files come from published posts and `config.yml`. Review generated diffs before committing them.
+
+## Validation
+
+For documentation-only changes:
+
+```bash
+pnpm lint
+```
+
+For code, config schema, content pipeline, or route changes:
+
+```bash
+pnpm run build
+```
+
+Use `pnpm lint:fix` when you want ESLint and formatters to apply safe fixes. The Git pre-commit hook runs `npx nano-staged`; the pre-push hook runs `pnpm run build`.
+
+## Deployment
+
+The template is designed for Vercel and can also run anywhere that supports a standard Next.js app.
+
+Before deploying:
+
+- Set `siteUrl` in `config.yml` to the public origin without a trailing slash.
+- Confirm public images, icons, RSS settings, and comment settings are correct.
+- Run `pnpm run build`.
+- Review generated `public/feed.xml`, `public/llms.txt`, and `public/llms-full.txt` if they changed.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,7 @@
 # Development Guide
 
+[English](./DEVELOPMENT.md) | [中文](./DEVELOPMENT_ZH.md)
+
 This guide covers local setup, content editing, validation, and deployment for SuzuBlog.
 
 ## Prerequisites

--- a/DEVELOPMENT_ZH.md
+++ b/DEVELOPMENT_ZH.md
@@ -1,0 +1,155 @@
+# 开发指南
+
+[English](./DEVELOPMENT.md) | [中文](./DEVELOPMENT_ZH.md)
+
+本指南覆盖 SuzuBlog 的本地设置、内容编辑、校验和部署。
+
+## 前置要求
+
+- Node.js >= 22，优先匹配 `.node-version`
+- pnpm，匹配 `package.json` 中的 `packageManager`
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+## 本地开发
+
+启动应用：
+
+```bash
+pnpm dev
+```
+
+打开：
+
+```text
+http://localhost:3000/
+```
+
+构建生产版本：
+
+```bash
+pnpm run build
+```
+
+启动已构建的生产应用：
+
+```bash
+pnpm start
+```
+
+## 可用脚本
+
+- `pnpm dev`：启动 Next.js 开发服务器。
+- `pnpm run build`：先运行 `pnpm run lint:fix`，再运行 `next build`。
+- `pnpm start`：在构建后启动生产 Next.js 服务。
+- `pnpm lint`：运行 ESLint。
+- `pnpm lint:fix`：运行 ESLint 并应用自动修复。
+
+当前没有配置测试脚本。文档相关变更优先使用 `pnpm lint` 或 `pnpm run build` 校验；如果未来的改动引入需要测试覆盖的行为，应添加聚焦的测试。
+
+## 配置
+
+编辑 `config.yml` 管理站点级设置：
+
+- 标题、副标题、描述、关键词、语言和站点 URL
+- 作者资料和头像/背景图
+- 分页和内容许可证默认值
+- 社交链接和 RSS 可见性
+- Twikoo 或 Disqus 评论集成
+- 自定义 head 脚本和 footer HTML
+
+配置会在运行时通过 Zod 校验。如果添加新的配置字段，需要同时更新 `config.yml` 和 `src/schemas/config.ts`。
+
+## 内容编辑
+
+在 `posts` 中创建 Markdown 文章：
+
+```text
+posts/my-post.md
+```
+
+特殊页面放在 `posts/_pages`：
+
+```text
+posts/_pages/About.md
+posts/_pages/Friends.md
+```
+
+典型文章 frontmatter：
+
+```yaml
+---
+title: My Post
+date: '2026-05-29 09:00:00'
+thumbnail: /images/background.jpg
+categories:
+  - Notes
+tags:
+  - Next.js
+  - Markdown
+---
+```
+
+使用 `<!--more-->` 控制文章列表中的摘要。没有该标记时，摘要会从文章开头内容自动生成。
+
+## 文章可见性
+
+文章可见性由可选的 `status` frontmatter 字段控制：
+
+- `published`：显示在列表、生成页面、站点地图、RSS 和 LLM 文件中。
+- `unlisted`：页面可以渲染，但会从列表和生成给爬虫使用的输出中排除。
+- `draft`：非生产环境可用；生产环境需要 `ALLOW_DRAFTS=true`。
+- `hidden`：仅在非生产环境且 `ALLOW_HIDDEN=true` 时可用。
+
+如果省略 `status`，文章会被视为 `published`。
+
+## 资源
+
+静态资源放在 `public` 下。文章和配置使用的图片通常放在 `public/images`，并从站点根路径引用：
+
+```md
+![Alt text](/images/example.jpg)
+```
+
+`next/image` 允许 `/images/**` 下的本地图片和远程 HTTPS 图片。
+
+## 生成文件
+
+构建过程可能重新生成：
+
+- `public/feed.xml`
+- `public/llms.txt`
+- `public/llms-full.txt`
+
+这些文件来自已发布文章和 `config.yml`。提交前请检查生成文件 diff。
+
+## 校验
+
+仅文档变更：
+
+```bash
+pnpm lint
+```
+
+代码、配置 schema、内容管线或路由变更：
+
+```bash
+pnpm run build
+```
+
+需要 ESLint 和 formatter 自动应用安全修复时，使用 `pnpm lint:fix`。Git pre-commit hook 会运行 `npx nano-staged`；pre-push hook 会运行 `pnpm run build`。
+
+## 部署
+
+该模板为 Vercel 设计，也可以运行在任何支持标准 Next.js 应用的平台。
+
+部署前确认：
+
+- `config.yml` 中的 `siteUrl` 是不带末尾斜杠的公开 origin。
+- 公共图片、图标、RSS 设置和评论设置正确。
+- 已运行 `pnpm run build`。
+- 如果 `public/feed.xml`、`public/llms.txt`、`public/llms-full.txt` 发生变化，已检查对应 diff。

--- a/DEVELOPMENT_ZH.md
+++ b/DEVELOPMENT_ZH.md
@@ -6,7 +6,7 @@
 
 ## 前置要求
 
-- Node.js >= 22，优先匹配 `.node-version`
+- Node.js >= 20.9.0，优先匹配 `.node-version`
 - pnpm，匹配 `package.json` 中的 `packageManager`
 
 安装依赖：

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Need help with setup, customization, or deployment? Check out the full documenta
 
 📖 **[Suzu Blog Docs](https://suzu.zla.app)**
 
+## 📚 Repository Docs
+
+- [Architecture](./ARCHITECTURE.md) | [中文](./ARCHITECTURE_ZH.md)
+- [Development Guide](./DEVELOPMENT.md) | [中文](./DEVELOPMENT_ZH.md)
+- [Contribution Guide](./CONTRIBUTING.md) | [中文](./CONTRIBUTING_ZH.md)
+
 ## 🏗️ Project Structure
 
 ```plaintext

--- a/README_JA.md
+++ b/README_JA.md
@@ -34,6 +34,12 @@
 
 📖 **[Suzu Blog ドキュメント](https://suzu.zla.app)**
 
+## 📚 リポジトリドキュメント
+
+- [Architecture](./ARCHITECTURE.md) | [中文](./ARCHITECTURE_ZH.md)
+- [Development Guide](./DEVELOPMENT.md) | [中文](./DEVELOPMENT_ZH.md)
+- [Contribution Guide](./CONTRIBUTING.md) | [中文](./CONTRIBUTING_ZH.md)
+
 ## 🏗️ プロジェクト構造
 
 ```plaintext
@@ -73,7 +79,7 @@
 [license-link]: ./LICENSE
 [nextjs-badge]: https://img.shields.io/badge/Next.js-black?logo=next.js&logoColor=white
 [nextjs-link]: https://nextjs.org
-[node-badge]: https://img.shields.io/badge/node%3E=18.18-339933?logo=node.js&logoColor=white
+[node-badge]: https://img.shields.io/badge/node%3E=20.9.0-339933?logo=node.js&logoColor=white
 [node-link]: https://nodejs.org/
 [pnpm-badge]: https://img.shields.io/github/package-json/packageManager/ZL-Asica/SuzuBlog?label=&logo=pnpm&logoColor=fff&color=F69220
 [pnpm-link]: https://pnpm.io/

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -79,7 +79,7 @@
 [license-link]: ./LICENSE
 [nextjs-badge]: https://img.shields.io/badge/Next.js-black?logo=next.js&logoColor=white
 [nextjs-link]: https://nextjs.org
-[node-badge]: https://img.shields.io/badge/node%3E=18.18-339933?logo=node.js&logoColor=white
+[node-badge]: https://img.shields.io/badge/node%3E=20.9.0-339933?logo=node.js&logoColor=white
 [node-link]: https://nodejs.org/
 [pnpm-badge]: https://img.shields.io/github/package-json/packageManager/ZL-Asica/SuzuBlog?label=&logo=pnpm&logoColor=fff&color=F69220
 [pnpm-link]: https://pnpm.io/

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -34,6 +34,12 @@
 
 📖 **[Suzu Blog 官方文档](https://suzu.zla.app)**
 
+## 📚 仓库文档
+
+- [架构说明](./ARCHITECTURE_ZH.md) | [English](./ARCHITECTURE.md)
+- [开发指南](./DEVELOPMENT_ZH.md) | [English](./DEVELOPMENT.md)
+- [贡献指南](./CONTRIBUTING_ZH.md) | [English](./CONTRIBUTING.md)
+
 ## 🏗️ 项目结构
 
 ```plaintext


### PR DESCRIPTION
## ✨ Documentation Update

### 📌 Description

Align repository documentation with the current SuzuBlog project structure and add Chinese documentation coverage for the main repository guides.

### 🔍 Feature Changes

- [x] Other: add and update repository documentation.

### ✅ Checklist

1. Feature Updates:

- [x] Documentation follows the current Next.js + Markdown project structure.
- [x] Relevant documentation is updated.
- [x] Repository README files link to the new documentation pages.

### 💬 Additional Notes

- Added repository guides for architecture, development, and contribution workflow.
- Added Chinese versions for architecture, development, and contribution docs.
- Updated README, README_ZH, and README_JA repository documentation links.
- Standardized the documented Node.js baseline to `>= 20.9.0` for Next.js 16 compatibility.
